### PR TITLE
Fix remove unused created by

### DIFF
--- a/squirrel/orders/tests.py
+++ b/squirrel/orders/tests.py
@@ -315,11 +315,13 @@ class TeamViewTests(TestCase):
         self.client.login(username="loc_engel", password="loc_engel")
         response = self.client.post("/teams/new", {"name": "Creatures"})
         self.assertEqual(response.status_code, 403)
+        self.assertEqual(Team.objects.all().count(), 0)
 
     def test_require_add_permission_ok(self):
         self.client.login(username="order_engel", password="order_engel")
         response = self.client.post("/teams/new", {"name": "Creatures"})
         self.assertEqual(response.status_code, 302)
+        self.assertEqual(Team.objects.all().count(), 1)
 
     def test_require_change_permission_fails(self):
         team = Team(name="BadWolf")

--- a/squirrel/orders/views.py
+++ b/squirrel/orders/views.py
@@ -145,11 +145,7 @@ def team(request, team_id=None):
                 raise PermissionDenied
 
         if form.is_valid():
-            team_object = form.save(commit=False)
-            if not team_id:
-                team_object.created_by = request.user
-            team_object.save()
-
+            form.save()
             return redirect("teams")
     else:
         if team_object:


### PR DESCRIPTION
The field created_by is set in the view, but there is no such field in the model.
this removes the unused code from the view.

dryve-by-code-injection: improved some tests.